### PR TITLE
fix: remove codecov package requirement

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,20 @@
 #
 #    pip-compile --output-file=requirements/ci.txt requirements/ci.in
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@ appdirs==1.4.4
     # via fs
 asgiref==3.6.0
     # via django
-boto3==1.26.94
+boto3==1.26.114
     # via fs-s3fs
-botocore==1.29.94
+botocore==1.29.114
     # via
     #   boto3
     #   s3transfer
@@ -24,7 +24,7 @@ django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
@@ -38,13 +38,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-packaging==23.0
+packaging==23.1
     # via
     #   build
     #   tox
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/dev.in
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -54,7 +54,7 @@ pyproject-hooks==1.0.0
     # via build
 python-dateutil==2.8.2
     # via botocore
-pytz==2022.7.1
+pytz==2023.3
     # via django
 s3transfer==0.6.0
     # via boto3

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,26 +12,22 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.3
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 backports-functools-lru-cache==1.6.4
     # via caniusepython3
 bleach==6.0.0
     # via readme-renderer
 boto==2.49.0
     # via -r requirements/test.txt
-boto3==1.26.94
+boto3==1.26.114
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
     #   moto
-botocore==1.29.94
+botocore==1.29.114
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -60,15 +56,14 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.2
     # via
     #   -r requirements/test.txt
     #   moto
-    #   secretstorage
 dill==0.3.6
     # via pylint
 distlib==0.3.6
@@ -95,7 +90,7 @@ idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.1.0
+importlib-metadata==6.4.1
     # via
     #   keyring
     #   twine
@@ -111,10 +106,6 @@ isort==5.12.0
     #   pylint
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -140,13 +131,13 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.txt
 more-itertools==9.1.0
     # via jaraco-classes
-moto==4.1.5
+moto==4.1.7
     # via -r requirements/test.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   caniusepython3
@@ -155,7 +146,7 @@ pbr==5.11.1
     # via stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -169,11 +160,11 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   rich
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -189,7 +180,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pypng==0.20220715.0
     # via -r requirements/test.txt
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -205,7 +196,7 @@ python-dateutil==2.8.2
     #   moto
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -232,14 +223,12 @@ responses==0.23.1
     #   moto
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
 s3transfer==0.6.0
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -264,11 +253,11 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 twine==4.0.2
     # via -r requirements/quality.in
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.9
     # via
     #   -r requirements/test.txt
     #   responses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,15 +8,13 @@ appdirs==1.4.4
     # via fs
 asgiref==3.6.0
     # via django
-attrs==22.2.0
-    # via pytest
 boto==2.49.0
     # via -r requirements/test.in
-boto3==1.26.94
+boto3==1.26.114
     # via
     #   fs-s3fs
     #   moto
-botocore==1.29.94
+botocore==1.29.114
     # via
     #   boto3
     #   moto
@@ -27,9 +25,9 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via pytest-cov
-cryptography==39.0.2
+cryptography==40.0.2
     # via moto
     # via
     #   -c requirements/common_constraints.txt
@@ -56,11 +54,11 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   werkzeug
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.in
-moto==4.1.5
+moto==4.1.7
     # via -r requirements/test.in
-packaging==23.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
@@ -68,7 +66,7 @@ pycparser==2.21
     # via cffi
 pypng==0.20220715.0
     # via -r requirements/test.in
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -81,7 +79,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   moto
-pytz==2022.7.1
+pytz==2023.3
     # via django
 pyyaml==6.0
     # via responses
@@ -104,7 +102,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.9
     # via responses
 urllib3==1.26.15
     # via


### PR DESCRIPTION
### Description
- Codecov deprecated the pypi package long ago (Feb 2022) but left it up until now.
- Removing the package from requirements to fix the failing upgrade job.
- The Github Action we use to upload to codecov doesn’t depend on the package so our CI coverage won’t be affected by the change