### PR TITLE
feat!: upgrading boto to boto3.

### DIFF
--- a/djpyfs/__init__.py
+++ b/djpyfs/__init__.py
@@ -1,3 +1,3 @@
 # pylint: disable=django-not-configured
 """init file"""
-__version__ = '3.2.1'
+__version__ = '3.3.0'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
-boto3==1.26.142
+boto3==1.26.145
     # via fs-s3fs
-botocore==1.29.142
+botocore==1.29.145
     # via
     #   boto3
     #   s3transfer
@@ -78,7 +78,7 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via asgiref
 urllib3==1.26.16
     # via botocore

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -20,14 +20,12 @@ backports-functools-lru-cache==1.6.4
     # via caniusepython3
 bleach==6.0.0
     # via readme-renderer
-boto==2.49.0
-    # via -r requirements/test.txt
-boto3==1.26.142
+boto3==1.26.145
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
     #   moto
-botocore==1.29.142
+botocore==1.29.145
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -56,11 +54,11 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/test.txt
     #   moto
@@ -228,7 +226,7 @@ responses==0.23.1
     #   moto
 rfc3986==2.0.0
     # via twine
-rich==13.3.5
+rich==13.4.1
     # via twine
 s3transfer==0.6.1
     # via
@@ -268,7 +266,7 @@ types-pyyaml==6.0.12.10
     # via
     #   -r requirements/test.txt
     #   responses
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -r requirements/test.txt
     #   asgiref

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,7 +3,6 @@
 -c constraints.txt
 
 mock           # For setup of testing corner cases
-boto           # TODO: required for some tests, needs to be removed after updating tests
 moto           # For mocking the boto3 Amazon S3 API
 pypng          # For the sample app
 pytest         # Test runner

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,13 +8,11 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
-boto==2.49.0
-    # via -r requirements/test.in
-boto3==1.26.142
+boto3==1.26.145
     # via
     #   fs-s3fs
     #   moto
-botocore==1.29.142
+botocore==1.29.145
     # via
     #   boto3
     #   moto
@@ -25,9 +23,9 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via moto
     # via
     #   -c requirements/common_constraints.txt
@@ -104,7 +102,7 @@ tomli==2.0.1
     #   pytest
 types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via asgiref
 urllib3==1.26.16
     # via


### PR DESCRIPTION
[Ticket info](https://github.com/edx/edx-arch-experiments/issues/315) Ultimate target is to remove `boto` usage from edx-platform.

Removing `boto` from `xblock-sdk`. This  [PR](https://github.com/openedx/xblock-sdk/pull/287)  throws error 

Xblock [PR](https://github.com/openedx/xblock-sdk/pull/287) looks fine with hash.
Xblock-sdk [PR](https://github.com/openedx/xblock-sdk/pull/287) looks fine with hash.

I have updated the tests urls format because both boto and boto3 generates different format versions.
master branch
```
S3CONN.generate_url(timeout, 'GET', bucket=DJFS_SETTINGS['bucket'], key=os.path.join(fullpath, filename))
Above line generates URL as follows
'https://test_bucket.s3.amazonaws.com:443/unitttest/unit_test_dir/unit_test_file?Signature=s0ifgcqm%2BgDeOSjIjLgfOCV%2Bzm4%3D&Expires=1685086458&AWSAccessKeyId=foo
```

With new boto3 url format is different
```
'https://s3.amazonaws.com/test_bucket/unitttest/unit_test_dir/unit_test_file?AWSAccessKeyId=foo&Signature=J53ZTU7TQGpxzjVJK3S8MbSmnEE%3D&Expires=1685129437'
```