### PR TITLE
fix: pass AWS credentials correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,23 @@
+Change Log
+##########
+
+..
+   All enhancements and patches to openedx-django-pyfs will be documented
+   in this file.  It adheres to the structure of https://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+
+   This project adheres to Semantic Versioning (https://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+
+Unreleased
+**********
+
+3.4.1
+*****
+
+Fixed
+=====
+
+* fix: pass AWS credentials correctly (#168)

--- a/djpyfs/__init__.py
+++ b/djpyfs/__init__.py
@@ -1,3 +1,3 @@
 # pylint: disable=django-not-configured
 """init file"""
-__version__ = '3.4.0'
+__version__ = '3.4.1'

--- a/djpyfs/djpyfs.py
+++ b/djpyfs/djpyfs.py
@@ -132,7 +132,7 @@ def get_s3fs(namespace):
     if 'prefix' in DJFS_SETTINGS:
         fullpath = os.path.join(DJFS_SETTINGS['prefix'], fullpath)
 
-    s3fs = S3FS(DJFS_SETTINGS['bucket'], fullpath, aws_secret_access_key=key_id, aws_access_key_id=key_secret)
+    s3fs = S3FS(DJFS_SETTINGS['bucket'], fullpath, aws_access_key_id=key_id, aws_secret_access_key=key_secret)
 
     def get_s3_url(self, filename, timeout=60):  # pylint: disable=unused-argument
         """

--- a/djpyfs/tests.py
+++ b/djpyfs/tests.py
@@ -320,6 +320,11 @@ class S3Test(_BaseFs):
         self.conn = boto3.resource('s3')
         self.conn.create_bucket(Bucket=djpyfs.DJFS_SETTINGS['bucket'])
 
+    def test_aws_credentials(self):
+        fs = djpyfs.get_filesystem(self.namespace)
+        self.assertEqual(fs.aws_access_key_id, 'foo')
+        self.assertEqual(fs.aws_secret_access_key, 'bar')
+
     # This test is only relevant for S3. Generate some fake errors to make
     # sure we cover the retry code.
     def test_get_url_retry(self):


### PR DESCRIPTION
## Description

Fixes passing of AWS credentials, which are currently passed in inverse order.

## Supporting information

https://discuss.openedx.org/t/bug-report-openedx-django-pyfs-uses-s3-access-key-id-and-secret-in-place-of-each-other/11874

## Testing instructions

1. Explicitly set 'aws_access_key_id' and 'aws_secret_access_key' in settings.DJFS.
2. Test that objects in the bucket are accessible.

## Deadline

None