### PR TITLE
Dropped django 4.2 support. Bumped dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest]
         python-version:
         - '3.12'
-        toxenv: [quality, django42, django52]
+        toxenv: [quality, django52]
 
     steps:
     - name: checkout repo
@@ -37,7 +37,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.12' && matrix.toxenv=='django42'
+      if: matrix.python-version == '3.12' && matrix.toxenv=='django52'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 **********
 
+* Dropped Django 4.2 from CI test matrix; bumped boto3/botocore, tox, virtualenv
+
 3.8.0
 *****
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -28,11 +28,11 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.1.3
+python-discovery==1.2.0
     # via virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.49.1
+tox==4.50.3
     # via -r requirements/ci.in
 virtualenv==21.2.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,13 +8,13 @@ appdirs==1.4.4
     # via fs
 asgiref==3.11.1
     # via django
-boto3==1.42.68
+boto3==1.42.75
     # via fs-s3fs
-botocore==1.42.68
+botocore==1.42.75
     # via
     #   boto3
     #   s3transfer
-build==1.4.0
+build==1.4.2
     # via pip-tools
 cachetools==7.0.5
     # via tox
@@ -66,7 +66,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 python-dateutil==2.9.0.post0
     # via botocore
-python-discovery==1.1.3
+python-discovery==1.2.0
     # via virtualenv
 s3transfer==0.16.0
     # via boto3
@@ -79,7 +79,7 @@ sqlparse==0.5.5
     # via django
 tomli-w==1.2.0
     # via tox
-tox==4.49.1
+tox==4.50.3
     # via -r requirements/dev.in
 urllib3==2.6.3
     # via botocore

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/pip-tools.txt requirements/pip-tools.in
 #
-build==1.4.0
+build==1.4.2
     # via pip-tools
 click==8.3.1
     # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,12 +18,12 @@ astroid==4.0.4
     #   pylint-celery
 backports-tarfile==1.2.0
     # via jaraco-context
-boto3==1.42.68
+boto3==1.42.75
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
     #   moto
-botocore==1.42.68
+botocore==1.42.75
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -50,7 +50,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==2.3.2
     # via edx-lint
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -58,7 +58,6 @@ cryptography==46.0.5
     # via
     #   -r requirements/test.txt
     #   moto
-    #   secretstorage
 dill==0.4.1
     # via pylint
 django==5.2.12
@@ -81,7 +80,7 @@ idna==3.11
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==8.7.1
+importlib-metadata==9.0.0
     # via keyring
 iniconfig==2.3.0
     # via
@@ -93,14 +92,10 @@ isort==8.0.1
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.1
+jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
@@ -134,7 +129,7 @@ moto==4.2.14
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-nh3==0.3.3
+nh3==0.3.4
     # via readme-renderer
 packaging==26.0
     # via
@@ -183,7 +178,7 @@ pytest==9.0.2
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt
@@ -201,7 +196,7 @@ pyyaml==6.0.3
     #   responses
 readme-renderer==44.0
     # via twine
-requests==2.32.5
+requests==2.33.0
     # via
     #   -r requirements/test.txt
     #   moto
@@ -222,8 +217,6 @@ s3transfer==0.16.0
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.5.0
-    # via keyring
 six==1.17.0
     # via
     #   -r requirements/test.txt
@@ -253,7 +246,7 @@ urllib3==2.6.3
     #   requests
     #   responses
     #   twine
-werkzeug==3.1.6
+werkzeug==3.1.7
     # via
     #   -r requirements/test.txt
     #   moto

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,11 +8,11 @@ appdirs==1.4.4
     # via fs
 asgiref==3.11.1
     # via django
-boto3==1.42.68
+boto3==1.42.75
     # via
     #   fs-s3fs
     #   moto
-botocore==1.42.68
+botocore==1.42.75
     # via
     #   boto3
     #   moto
@@ -23,7 +23,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.6
     # via requests
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cryptography==46.0.5
     # via moto
@@ -73,7 +73,7 @@ pytest==9.0.2
     #   -r requirements/test.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 pytest-django==4.12.0
     # via -r requirements/test.in
@@ -83,7 +83,7 @@ python-dateutil==2.9.0.post0
     #   moto
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.33.0
     # via
     #   moto
     #   responses
@@ -103,7 +103,7 @@ urllib3==2.6.3
     #   botocore
     #   requests
     #   responses
-werkzeug==3.1.6
+werkzeug==3.1.7
     # via moto
 xmltodict==1.0.4
     # via moto

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Django",
-        "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python{312}-django{42, 52},quality
+envlist = python{312}-django{52},quality
 
 [testenv]
 passenv =
@@ -11,7 +11,6 @@ commands =
     python -m coverage html
 deps =
     -r{toxinidir}/requirements/test.txt
-    django42: Django>=4.2,<5.0
     django52: Django>=5.1,<5.3
 
 [testenv:quality]


### PR DESCRIPTION
Dropped django 4.2 support. Bumped dependencies

Issue: https://github.com/openedx/public-engineering/issues/458